### PR TITLE
Support for default result and README addition

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,159 @@
+JSON serializable rules to match Jackson JsonNodes using JSON Pointers.
+
+###### Rule
+```json
+   {
+      "operator": "equals",
+      "value": "happy",
+      "path": "/mood"
+   }
+```
+
+###### Paylod
+```json
+   {
+      "name": "John Doe",
+      "mood": "happy"
+   }
+```
+
+Payload would match the rules when evaluated
+
+
+## Getting Started
+### Installation
+
+Maven repo
+```
+  <dependency>
+    <groupId>io.appform.rules</groupId>
+    <artifactId>json-rules</artifactId>
+    <version>0.3.2-SNAPSHOT</version>
+  </dependency>
+```
+
+### Usage
+```java
+    // Build expression with java objects
+    Expression expression = LessThanExpression.builder()
+                                .path("/value")
+                                .value(30)
+                                .build();
+    // Or read from serialized json sources
+    Expression expression = (new ObjectMapper()).readValue(expressionJson, Expression.class)
+    
+    // Get json payload to be evaluated
+    JsonNode jsonNode = objectMapper.readTree(productJson);
+    
+    boolean matches = expression.evaluate(jsonNode);
+```
+##### Operators
+
+
+###### General
+
+ * equals
+ * not_equals
+ * less_than 
+ * greater_than
+ * less_than_equals
+ * greater_than_equals
+
+```json
+   {
+      "operator": "equals",
+      "value": "happy",
+      "path": "/mood"
+   }
+```
+
+###### Composite/Boolean operators
+ * and
+ * not
+ * or
+```json
+   {
+      "operator": "and",
+      "children": [
+          {
+             "operator": "equals",
+             "value": "happy",
+             "path": "/mood"
+          },
+          {
+             "operator": "less_than",
+             "value": 1000,
+             "path": "/product.cost"
+          }
+      ]
+   }
+```
+###### Array Search
+
+ * not_in
+ * in
+
+```json
+   {
+      "operator": "in",
+      "path": "/mood",
+      "values": [
+        "happy",
+        "sad"
+      ]
+   }
+```
+
+###### Strings
+     * empty
+     * not_empty
+
+###### Path validations
+     * exists
+     * not_exists
+ 
+
+##### Default results
+
+For unstructured json evaluation you can specify a defaultResult value.
+The default value would be the evaluation result if `path` doesn't exist in the evaluation payload.
+
+```json
+   {
+      "operator": "equals",
+      "value": "happy",
+      "path": "/mood",
+      "defaultResult": true
+   }
+```
+
+##### Preoperations
+
+Pre-operations are pre-evaluation mutations that can be applied to payload.
+ 
+ * Datetime
+     * Epoch - Mutation rules for unix timestamp
+     * DateTime - Mutation rules for textual dates
+ * Numeric
+     * Divide
+     * Multiply
+     * Sum
+     * Difference
+     * modulo
+  
+```json
+    {
+        "type": "in",
+        "path": "/time",
+        "preoperation": {
+          "operation": "epoch",
+          "operand": "week_of_month",
+          "zoneOffSet": "+05:30"
+        },
+        "values": [
+          2,
+          4
+        ]
+    }
+```
+  

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.appform.rules</groupId>
     <artifactId>json-rules</artifactId>
-    <version>0.3.2-SNAPSHOT</version>
+    <version>0.3.3-SNAPSHOT</version>
 
     <distributionManagement>
         <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jackson.version>2.7.4</jackson.version>
-        <lombok.version>1.16.6</lombok.version>
+        <lombok.version>1.16.16</lombok.version>
         <junit.version>4.12</junit.version>
     </properties>
 

--- a/src/main/java/io/appform/jsonrules/expressions/JsonPathBasedExpression.java
+++ b/src/main/java/io/appform/jsonrules/expressions/JsonPathBasedExpression.java
@@ -39,30 +39,32 @@ public abstract class JsonPathBasedExpression extends Expression {
     private String path;
     private PreOperation<?> preoperation;
     private static final ObjectMapper mapper = new ObjectMapper();
-    private Boolean defaultResult;
+    private boolean defaultResult;
 
     protected JsonPathBasedExpression(ExpressionType type) {
         super(type);
     }
 
-    protected JsonPathBasedExpression(ExpressionType type, String path, Boolean defultResult, PreOperation<?> preoperation) {
+    protected JsonPathBasedExpression(ExpressionType type, String path, boolean defaultResult, PreOperation<?> preoperation) {
         this(type);
         this.path = path;
         this.preoperation = preoperation;
-        this.defaultResult = defultResult;
+        this.defaultResult = defaultResult;
     }
 
     @Override
     public final boolean evaluate(ExpressionEvaluationContext context) {
-        //T value = context.getParsedContext().read(path, clazz);
         JsonNode evaluatedNode = context.getNode().at(path);
-        if (null != defaultResult && evaluatedNode.isMissingNode()) {
-            return defaultResult;
-        }
+
         if (preoperation != null) {
         	val computedValue = preoperation.compute(evaluatedNode);
         	evaluatedNode = mapper.valueToTree(computedValue);
         }
+
+        if (evaluatedNode.isMissingNode()) {
+            return defaultResult;
+        }
+
         return evaluate(context, path, evaluatedNode);
     }
 

--- a/src/main/java/io/appform/jsonrules/expressions/JsonPathBasedExpression.java
+++ b/src/main/java/io/appform/jsonrules/expressions/JsonPathBasedExpression.java
@@ -39,21 +39,26 @@ public abstract class JsonPathBasedExpression extends Expression {
     private String path;
     private PreOperation<?> preoperation;
     private static final ObjectMapper mapper = new ObjectMapper();
+    private Boolean defaultResult;
 
     protected JsonPathBasedExpression(ExpressionType type) {
         super(type);
     }
 
-    protected JsonPathBasedExpression(ExpressionType type, String path, PreOperation<?> preoperation) {
+    protected JsonPathBasedExpression(ExpressionType type, String path, Boolean defultResult, PreOperation<?> preoperation) {
         this(type);
         this.path = path;
         this.preoperation = preoperation;
+        this.defaultResult = defultResult;
     }
 
     @Override
     public final boolean evaluate(ExpressionEvaluationContext context) {
         //T value = context.getParsedContext().read(path, clazz);
         JsonNode evaluatedNode = context.getNode().at(path);
+        if (null != defaultResult && evaluatedNode.isMissingNode()) {
+            return defaultResult;
+        }
         if (preoperation != null) {
         	val computedValue = preoperation.compute(evaluatedNode);
         	evaluatedNode = mapper.valueToTree(computedValue);

--- a/src/main/java/io/appform/jsonrules/expressions/equality/EqualsExpression.java
+++ b/src/main/java/io/appform/jsonrules/expressions/equality/EqualsExpression.java
@@ -42,8 +42,8 @@ public class EqualsExpression extends JsonPathBasedExpression {
     }
 
     @Builder
-    public EqualsExpression(String path, Object value, PreOperation<?> preoperation) {
-        super(ExpressionType.equals, path, preoperation);
+    public EqualsExpression(String path, Object value, Boolean defaultResult, PreOperation<?> preoperation) {
+        super(ExpressionType.equals, path, defaultResult, preoperation);
         this.value = value;
     }
 

--- a/src/main/java/io/appform/jsonrules/expressions/equality/EqualsExpression.java
+++ b/src/main/java/io/appform/jsonrules/expressions/equality/EqualsExpression.java
@@ -42,9 +42,13 @@ public class EqualsExpression extends JsonPathBasedExpression {
     }
 
     @Builder
-    public EqualsExpression(String path, Object value, Boolean defaultResult, PreOperation<?> preoperation) {
+    public EqualsExpression(String path, Object value, boolean defaultResult, PreOperation<?> preoperation) {
         super(ExpressionType.equals, path, defaultResult, preoperation);
         this.value = value;
+    }
+
+    public EqualsExpression(String path, Object value, PreOperation<?> preoperation) {
+        this(path, value,false, preoperation);
     }
 
     @Override

--- a/src/main/java/io/appform/jsonrules/expressions/equality/InExpression.java
+++ b/src/main/java/io/appform/jsonrules/expressions/equality/InExpression.java
@@ -41,8 +41,8 @@ public class InExpression extends JsonPathBasedExpression {
     }
 
     @Builder
-    public InExpression(String path, @Singular List<Object> values, PreOperation<?> preoperation) {
-        super(ExpressionType.in, path, preoperation);
+    public InExpression(String path, @Singular List<Object> values, Boolean defaultResult, PreOperation<?> preoperation) {
+        super(ExpressionType.in, path, defaultResult, preoperation);
         this.values = values;
     }
 

--- a/src/main/java/io/appform/jsonrules/expressions/equality/InExpression.java
+++ b/src/main/java/io/appform/jsonrules/expressions/equality/InExpression.java
@@ -41,9 +41,13 @@ public class InExpression extends JsonPathBasedExpression {
     }
 
     @Builder
-    public InExpression(String path, @Singular List<Object> values, Boolean defaultResult, PreOperation<?> preoperation) {
+    public InExpression(String path, @Singular List<Object> values, boolean defaultResult, PreOperation<?> preoperation) {
         super(ExpressionType.in, path, defaultResult, preoperation);
         this.values = values;
+    }
+
+    public InExpression(String path, List<Object> values, PreOperation<?> preoperation) {
+        this(path, values, false, preoperation);
     }
 
     @Override

--- a/src/main/java/io/appform/jsonrules/expressions/equality/NotEqualsExpression.java
+++ b/src/main/java/io/appform/jsonrules/expressions/equality/NotEqualsExpression.java
@@ -42,8 +42,8 @@ public class NotEqualsExpression extends JsonPathBasedExpression {
     }
 
     @Builder
-    public NotEqualsExpression(String path, Object value, PreOperation<?> preoperation) {
-        super(ExpressionType.not_equals, path, preoperation);
+    public NotEqualsExpression(String path, Object value, Boolean defaultResult, PreOperation<?> preoperation) {
+        super(ExpressionType.not_equals, path, defaultResult, preoperation);
         this.value = value;
     }
 

--- a/src/main/java/io/appform/jsonrules/expressions/equality/NotEqualsExpression.java
+++ b/src/main/java/io/appform/jsonrules/expressions/equality/NotEqualsExpression.java
@@ -23,10 +23,8 @@ import io.appform.jsonrules.ExpressionType;
 import io.appform.jsonrules.expressions.JsonPathBasedExpression;
 import io.appform.jsonrules.expressions.preoperation.PreOperation;
 import io.appform.jsonrules.utils.ComparisonUtils;
-import lombok.Builder;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.ToString;
+import lombok.*;
+import lombok.experimental.Tolerate;
 
 /**
  * Compares objects
@@ -43,7 +41,7 @@ public class NotEqualsExpression extends JsonPathBasedExpression {
 
     @Builder
     public NotEqualsExpression(String path, Object value, Boolean defaultResult, PreOperation<?> preoperation) {
-        super(ExpressionType.not_equals, path, defaultResult, preoperation);
+        super(ExpressionType.not_equals, path, null == defaultResult ? true : defaultResult.booleanValue(), preoperation);
         this.value = value;
     }
 
@@ -52,7 +50,5 @@ public class NotEqualsExpression extends JsonPathBasedExpression {
         return value == null
                 || ComparisonUtils.isNodeMissingOrNull(evaluatedNode)
                 || ComparisonUtils.compare(evaluatedNode, value) != 0;
-
-
     }
 }

--- a/src/main/java/io/appform/jsonrules/expressions/equality/NotEqualsExpression.java
+++ b/src/main/java/io/appform/jsonrules/expressions/equality/NotEqualsExpression.java
@@ -41,7 +41,7 @@ public class NotEqualsExpression extends JsonPathBasedExpression {
 
     @Builder
     public NotEqualsExpression(String path, Object value, Boolean defaultResult, PreOperation<?> preoperation) {
-        super(ExpressionType.not_equals, path, null == defaultResult ? true : defaultResult.booleanValue(), preoperation);
+        super(ExpressionType.not_equals, path, ComparisonUtils.getDefaultResult(defaultResult, true), preoperation);
         this.value = value;
     }
 

--- a/src/main/java/io/appform/jsonrules/expressions/equality/NotInExpression.java
+++ b/src/main/java/io/appform/jsonrules/expressions/equality/NotInExpression.java
@@ -42,7 +42,7 @@ public class NotInExpression extends JsonPathBasedExpression {
 
     @Builder
     public NotInExpression(String path, @Singular List<Object> values, Boolean defaultResult, PreOperation<?> preoperation) {
-        super(ExpressionType.not_in, path, defaultResult, preoperation);
+        super(ExpressionType.not_in, path, null == defaultResult? true : defaultResult.booleanValue(), preoperation);
         this.values = values;
     }
 

--- a/src/main/java/io/appform/jsonrules/expressions/equality/NotInExpression.java
+++ b/src/main/java/io/appform/jsonrules/expressions/equality/NotInExpression.java
@@ -41,8 +41,8 @@ public class NotInExpression extends JsonPathBasedExpression {
     }
 
     @Builder
-    public NotInExpression(String path, @Singular List<Object> values, PreOperation<?> preoperation) {
-        super(ExpressionType.not_in, path, preoperation);
+    public NotInExpression(String path, @Singular List<Object> values, Boolean defaultResult, PreOperation<?> preoperation) {
+        super(ExpressionType.not_in, path, defaultResult, preoperation);
         this.values = values;
     }
 

--- a/src/main/java/io/appform/jsonrules/expressions/equality/NotInExpression.java
+++ b/src/main/java/io/appform/jsonrules/expressions/equality/NotInExpression.java
@@ -42,7 +42,7 @@ public class NotInExpression extends JsonPathBasedExpression {
 
     @Builder
     public NotInExpression(String path, @Singular List<Object> values, Boolean defaultResult, PreOperation<?> preoperation) {
-        super(ExpressionType.not_in, path, null == defaultResult? true : defaultResult.booleanValue(), preoperation);
+        super(ExpressionType.not_in, path, ComparisonUtils.getDefaultResult(defaultResult, true), preoperation);
         this.values = values;
     }
 

--- a/src/main/java/io/appform/jsonrules/expressions/meta/ExistsExpression.java
+++ b/src/main/java/io/appform/jsonrules/expressions/meta/ExistsExpression.java
@@ -35,7 +35,7 @@ public class ExistsExpression extends JsonPathBasedExpression {
 
     @Builder
     public ExistsExpression(String path, PreOperation<?> preoperation) {
-        super(ExpressionType.exists, path, preoperation);
+        super(ExpressionType.exists, path, null, preoperation);
     }
 
     @Override

--- a/src/main/java/io/appform/jsonrules/expressions/meta/ExistsExpression.java
+++ b/src/main/java/io/appform/jsonrules/expressions/meta/ExistsExpression.java
@@ -35,7 +35,7 @@ public class ExistsExpression extends JsonPathBasedExpression {
 
     @Builder
     public ExistsExpression(String path, PreOperation<?> preoperation) {
-        super(ExpressionType.exists, path, null, preoperation);
+        super(ExpressionType.exists, path, false, preoperation);
     }
 
     @Override

--- a/src/main/java/io/appform/jsonrules/expressions/meta/NotExistsExpression.java
+++ b/src/main/java/io/appform/jsonrules/expressions/meta/NotExistsExpression.java
@@ -35,7 +35,7 @@ public class NotExistsExpression extends JsonPathBasedExpression {
 
     @Builder
     public NotExistsExpression(String path, PreOperation<?> preoperation) {
-        super(ExpressionType.not_exists, path, preoperation);
+        super(ExpressionType.not_exists, path, null, preoperation);
     }
 
     @Override

--- a/src/main/java/io/appform/jsonrules/expressions/meta/NotExistsExpression.java
+++ b/src/main/java/io/appform/jsonrules/expressions/meta/NotExistsExpression.java
@@ -35,7 +35,7 @@ public class NotExistsExpression extends JsonPathBasedExpression {
 
     @Builder
     public NotExistsExpression(String path, PreOperation<?> preoperation) {
-        super(ExpressionType.not_exists, path, null, preoperation);
+        super(ExpressionType.not_exists, path, true, preoperation);
     }
 
     @Override

--- a/src/main/java/io/appform/jsonrules/expressions/numeric/GreaterThanEqualsExpression.java
+++ b/src/main/java/io/appform/jsonrules/expressions/numeric/GreaterThanEqualsExpression.java
@@ -31,8 +31,12 @@ public class GreaterThanEqualsExpression extends NumericJsonPathBasedExpression 
     }
 
     @Builder
-    public GreaterThanEqualsExpression(String path, Number value, Boolean defaultResult, PreOperation<?> preoperation) {
+    public GreaterThanEqualsExpression(String path, Number value, boolean defaultResult, PreOperation<?> preoperation) {
         super(ExpressionType.greater_than_equals, path, value, defaultResult, preoperation);
+    }
+
+    public GreaterThanEqualsExpression(String path, Number value, PreOperation<?> preoperation) {
+        this(path, value, false, preoperation);
     }
 
     protected boolean evaluate(ExpressionEvaluationContext context, int comparisonResult) {

--- a/src/main/java/io/appform/jsonrules/expressions/numeric/GreaterThanEqualsExpression.java
+++ b/src/main/java/io/appform/jsonrules/expressions/numeric/GreaterThanEqualsExpression.java
@@ -31,8 +31,8 @@ public class GreaterThanEqualsExpression extends NumericJsonPathBasedExpression 
     }
 
     @Builder
-    public GreaterThanEqualsExpression(String path, Number value, PreOperation<?> preoperation) {
-        super(ExpressionType.greater_than_equals, path, value, preoperation);
+    public GreaterThanEqualsExpression(String path, Number value, Boolean defaultResult, PreOperation<?> preoperation) {
+        super(ExpressionType.greater_than_equals, path, value, defaultResult, preoperation);
     }
 
     protected boolean evaluate(ExpressionEvaluationContext context, int comparisonResult) {

--- a/src/main/java/io/appform/jsonrules/expressions/numeric/GreaterThanExpression.java
+++ b/src/main/java/io/appform/jsonrules/expressions/numeric/GreaterThanExpression.java
@@ -31,8 +31,8 @@ public class GreaterThanExpression extends NumericJsonPathBasedExpression {
     }
 
     @Builder
-    public GreaterThanExpression(String path, Number value, PreOperation<?> preoperation) {
-        super(ExpressionType.greater_than, path, value, preoperation);
+    public GreaterThanExpression(String path, Number value, Boolean defaultResult, PreOperation<?> preoperation) {
+        super(ExpressionType.greater_than, path, value, defaultResult, preoperation);
     }
 
     protected boolean evaluate(ExpressionEvaluationContext context, int comparisonResult) {

--- a/src/main/java/io/appform/jsonrules/expressions/numeric/GreaterThanExpression.java
+++ b/src/main/java/io/appform/jsonrules/expressions/numeric/GreaterThanExpression.java
@@ -31,8 +31,12 @@ public class GreaterThanExpression extends NumericJsonPathBasedExpression {
     }
 
     @Builder
-    public GreaterThanExpression(String path, Number value, Boolean defaultResult, PreOperation<?> preoperation) {
+    public GreaterThanExpression(String path, Number value, boolean defaultResult, PreOperation<?> preoperation) {
         super(ExpressionType.greater_than, path, value, defaultResult, preoperation);
+    }
+
+    public GreaterThanExpression(String path, Number value, PreOperation<?> preoperation) {
+        this(path, value, false, preoperation);
     }
 
     protected boolean evaluate(ExpressionEvaluationContext context, int comparisonResult) {

--- a/src/main/java/io/appform/jsonrules/expressions/numeric/LessThanEqualsExpression.java
+++ b/src/main/java/io/appform/jsonrules/expressions/numeric/LessThanEqualsExpression.java
@@ -31,8 +31,12 @@ public class LessThanEqualsExpression extends NumericJsonPathBasedExpression {
     }
 
     @Builder
-    public LessThanEqualsExpression(String path, Number value, Boolean defaultResult, PreOperation<?> preoperation) {
+    public LessThanEqualsExpression(String path, Number value, boolean defaultResult, PreOperation<?> preoperation) {
         super(ExpressionType.less_than_equals, path, value, defaultResult, preoperation);
+    }
+
+    public LessThanEqualsExpression(String path, Number value, PreOperation<?> preoperation) {
+        this(path, value, false, preoperation);
     }
 
     protected boolean evaluate(ExpressionEvaluationContext context, int comparisonResult) {

--- a/src/main/java/io/appform/jsonrules/expressions/numeric/LessThanEqualsExpression.java
+++ b/src/main/java/io/appform/jsonrules/expressions/numeric/LessThanEqualsExpression.java
@@ -31,8 +31,8 @@ public class LessThanEqualsExpression extends NumericJsonPathBasedExpression {
     }
 
     @Builder
-    public LessThanEqualsExpression(String path, Number value, PreOperation<?> preoperation) {
-        super(ExpressionType.less_than_equals, path, value, preoperation);
+    public LessThanEqualsExpression(String path, Number value, Boolean defaultResult, PreOperation<?> preoperation) {
+        super(ExpressionType.less_than_equals, path, value, defaultResult, preoperation);
     }
 
     protected boolean evaluate(ExpressionEvaluationContext context, int comparisonResult) {

--- a/src/main/java/io/appform/jsonrules/expressions/numeric/LessThanExpression.java
+++ b/src/main/java/io/appform/jsonrules/expressions/numeric/LessThanExpression.java
@@ -31,8 +31,12 @@ public class LessThanExpression extends NumericJsonPathBasedExpression {
     }
 
     @Builder
-    public LessThanExpression(String path, Number value, Boolean defaultResult, PreOperation<?> preoperation) {
+    public LessThanExpression(String path, Number value, boolean defaultResult, PreOperation<?> preoperation) {
         super(ExpressionType.less_than, path, value, defaultResult, preoperation);
+    }
+
+    public LessThanExpression(String path, Number value, PreOperation<?> preoperation) {
+        this(path, value, false, preoperation);
     }
 
     protected boolean evaluate(ExpressionEvaluationContext context, int comparisonResult) {

--- a/src/main/java/io/appform/jsonrules/expressions/numeric/LessThanExpression.java
+++ b/src/main/java/io/appform/jsonrules/expressions/numeric/LessThanExpression.java
@@ -31,8 +31,8 @@ public class LessThanExpression extends NumericJsonPathBasedExpression {
     }
 
     @Builder
-    public LessThanExpression(String path, Number value, PreOperation<?> preoperation) {
-        super(ExpressionType.less_than, path, value, preoperation);
+    public LessThanExpression(String path, Number value, Boolean defaultResult, PreOperation<?> preoperation) {
+        super(ExpressionType.less_than, path, value, defaultResult, preoperation);
     }
 
     protected boolean evaluate(ExpressionEvaluationContext context, int comparisonResult) {

--- a/src/main/java/io/appform/jsonrules/expressions/numeric/NumericJsonPathBasedExpression.java
+++ b/src/main/java/io/appform/jsonrules/expressions/numeric/NumericJsonPathBasedExpression.java
@@ -38,7 +38,7 @@ public abstract class NumericJsonPathBasedExpression extends JsonPathBasedExpres
         super(type);
     }
 
-    protected NumericJsonPathBasedExpression(ExpressionType type, String path, Number value, Boolean defaultResult, PreOperation<?> preoperation) {
+    protected NumericJsonPathBasedExpression(ExpressionType type, String path, Number value, boolean defaultResult, PreOperation<?> preoperation) {
         super(type, path, defaultResult, preoperation);
         this.value = value;
     }

--- a/src/main/java/io/appform/jsonrules/expressions/numeric/NumericJsonPathBasedExpression.java
+++ b/src/main/java/io/appform/jsonrules/expressions/numeric/NumericJsonPathBasedExpression.java
@@ -34,13 +34,12 @@ import lombok.ToString;
 @ToString(callSuper = true)
 public abstract class NumericJsonPathBasedExpression extends JsonPathBasedExpression {
     private Number value;
-
     protected NumericJsonPathBasedExpression(ExpressionType type) {
         super(type);
     }
 
-    protected NumericJsonPathBasedExpression(ExpressionType type, String path, Number value, PreOperation<?> preoperation) {
-        super(type, path, preoperation);
+    protected NumericJsonPathBasedExpression(ExpressionType type, String path, Number value, Boolean defaultResult, PreOperation<?> preoperation) {
+        super(type, path, defaultResult, preoperation);
         this.value = value;
     }
 

--- a/src/main/java/io/appform/jsonrules/expressions/string/EmptyExpression.java
+++ b/src/main/java/io/appform/jsonrules/expressions/string/EmptyExpression.java
@@ -33,8 +33,8 @@ public class EmptyExpression extends JsonPathBasedExpression {
     }
 
     @Builder
-    public EmptyExpression(String path, PreOperation<?> preoperation) {
-        super(ExpressionType.empty, path, preoperation);
+    public EmptyExpression(String path, Boolean defaultResult, PreOperation<?> preoperation) {
+        super(ExpressionType.empty, path, defaultResult, preoperation);
     }
 
     @Override

--- a/src/main/java/io/appform/jsonrules/expressions/string/NotEmptyExpression.java
+++ b/src/main/java/io/appform/jsonrules/expressions/string/NotEmptyExpression.java
@@ -33,8 +33,8 @@ public class NotEmptyExpression extends JsonPathBasedExpression {
     }
 
     @Builder
-    public NotEmptyExpression(String path, PreOperation<?> preoperation) {
-        super(ExpressionType.not_empty, path, preoperation);
+    public NotEmptyExpression(String path, Boolean defaultResult, PreOperation<?> preoperation) {
+        super(ExpressionType.not_empty, path, defaultResult, preoperation);
     }
 
     @Override

--- a/src/main/java/io/appform/jsonrules/expressions/string/NotEmptyExpression.java
+++ b/src/main/java/io/appform/jsonrules/expressions/string/NotEmptyExpression.java
@@ -33,10 +33,13 @@ public class NotEmptyExpression extends JsonPathBasedExpression {
     }
 
     @Builder
-    public NotEmptyExpression(String path, Boolean defaultResult, PreOperation<?> preoperation) {
+    public NotEmptyExpression(String path, boolean defaultResult, PreOperation<?> preoperation) {
         super(ExpressionType.not_empty, path, defaultResult, preoperation);
     }
 
+    public NotEmptyExpression(String path, PreOperation<?> preoperation) {
+        this(path, false, preoperation);
+    }
     @Override
     protected boolean evaluate(ExpressionEvaluationContext context, String path, JsonNode evaluatedNode) {
         if(!evaluatedNode.isTextual()) {

--- a/src/main/java/io/appform/jsonrules/utils/ComparisonUtils.java
+++ b/src/main/java/io/appform/jsonrules/utils/ComparisonUtils.java
@@ -62,7 +62,8 @@ public interface ComparisonUtils {
     }
 
     public static boolean getDefaultResult(Boolean defaultResult, boolean resultIfNull) {
-        if (null == defaultResult) return resultIfNull;
+        if (null == defaultResult)
+            return resultIfNull;
         return defaultResult.booleanValue();
     }
 }

--- a/src/main/java/io/appform/jsonrules/utils/ComparisonUtils.java
+++ b/src/main/java/io/appform/jsonrules/utils/ComparisonUtils.java
@@ -60,4 +60,9 @@ public interface ComparisonUtils {
     public static boolean isNodeMissingOrNull(JsonNode node) {
         return node.isMissingNode() || node.isNull();
     }
+
+    public static boolean getDefaultResult(Boolean defaultResult, boolean resultIfNull) {
+        if (null == defaultResult) return resultIfNull;
+        return defaultResult.booleanValue();
+    }
 }

--- a/src/test/java/io/appform/jsonrules/AddOperationTest.java
+++ b/src/test/java/io/appform/jsonrules/AddOperationTest.java
@@ -286,7 +286,7 @@ public class AddOperationTest {
         final String ruleRep = rule.representation(mapper);
 
         System.out.println(ruleRep);
-        Assert.assertEquals("{\"type\":\"not\",\"children\":[{\"type\":\"or\",\"children\":[{\"type\":\"less_than\",\"path\":\"/value\",\"preoperation\":{\"operation\":\"add\",\"operand\":5},\"value\":11},{\"type\":\"greater_than\",\"path\":\"/value\",\"preoperation\":{\"operation\":\"add\",\"operand\":-5},\"value\":30}]}]}", ruleRep);
+        Assert.assertEquals("{\"type\":\"not\",\"children\":[{\"type\":\"or\",\"children\":[{\"type\":\"less_than\",\"path\":\"/value\",\"preoperation\":{\"operation\":\"add\",\"operand\":5},\"defaultResult\":false,\"value\":11},{\"type\":\"greater_than\",\"path\":\"/value\",\"preoperation\":{\"operation\":\"add\",\"operand\":-5},\"defaultResult\":false,\"value\":30}]}]}", ruleRep);
     }
     
 }

--- a/src/test/java/io/appform/jsonrules/DateTimeOperationTest.java
+++ b/src/test/java/io/appform/jsonrules/DateTimeOperationTest.java
@@ -460,7 +460,7 @@ public class DateTimeOperationTest {
         final String ruleRep = rule.representation(mapper);
 
         System.out.println(ruleRep);
-        Assert.assertEquals("{\"type\":\"not\",\"children\":[{\"type\":\"or\",\"children\":[{\"type\":\"less_than\",\"path\":\"/unixTime\",\"preoperation\":{\"operation\":\"date_time\",\"operand\":\"hour_of_day\"},\"value\":11},{\"type\":\"greater_than\",\"path\":\"/unixTime\",\"preoperation\":{\"operation\":\"date_time\",\"operand\":\"week_of_month\"},\"value\":30}]}]}", ruleRep);
+        Assert.assertEquals("{\"type\":\"not\",\"children\":[{\"type\":\"or\",\"children\":[{\"type\":\"less_than\",\"path\":\"/unixTime\",\"preoperation\":{\"operation\":\"date_time\",\"operand\":\"hour_of_day\"},\"defaultResult\":false,\"value\":11},{\"type\":\"greater_than\",\"path\":\"/unixTime\",\"preoperation\":{\"operation\":\"date_time\",\"operand\":\"week_of_month\"},\"defaultResult\":false,\"value\":30}]}]}", ruleRep);
     }
     
 }

--- a/src/test/java/io/appform/jsonrules/DivideOperationTest.java
+++ b/src/test/java/io/appform/jsonrules/DivideOperationTest.java
@@ -337,7 +337,7 @@ public class DivideOperationTest {
         final String ruleRep = rule.representation(mapper);
 
         System.out.println(ruleRep);
-        Assert.assertEquals("{\"type\":\"not\",\"children\":[{\"type\":\"or\",\"children\":[{\"type\":\"less_than\",\"path\":\"/value\",\"preoperation\":{\"operation\":\"divide\",\"operand\":5},\"value\":11},{\"type\":\"greater_than\",\"path\":\"/value\",\"preoperation\":{\"operation\":\"divide\",\"operand\":-5},\"value\":30}]}]}", ruleRep);
+        Assert.assertEquals("{\"type\":\"not\",\"children\":[{\"type\":\"or\",\"children\":[{\"type\":\"less_than\",\"path\":\"/value\",\"preoperation\":{\"operation\":\"divide\",\"operand\":5},\"defaultResult\":false,\"value\":11},{\"type\":\"greater_than\",\"path\":\"/value\",\"preoperation\":{\"operation\":\"divide\",\"operand\":-5},\"defaultResult\":false,\"value\":30}]}]}", ruleRep);
     }
 
 }

--- a/src/test/java/io/appform/jsonrules/EpochOperationTest.java
+++ b/src/test/java/io/appform/jsonrules/EpochOperationTest.java
@@ -438,7 +438,7 @@ public class EpochOperationTest {
         final String ruleRep = rule.representation(mapper);
 
         System.out.println(ruleRep);
-        Assert.assertEquals("{\"type\":\"not\",\"children\":[{\"type\":\"or\",\"children\":[{\"type\":\"less_than\",\"path\":\"/unixTime\",\"preoperation\":{\"operation\":\"epoch\",\"operand\":\"hour_of_day\"},\"value\":11},{\"type\":\"greater_than\",\"path\":\"/unixTime\",\"preoperation\":{\"operation\":\"epoch\",\"operand\":\"week_of_month\"},\"value\":30}]}]}", ruleRep);
+        Assert.assertEquals("{\"type\":\"not\",\"children\":[{\"type\":\"or\",\"children\":[{\"type\":\"less_than\",\"path\":\"/unixTime\",\"preoperation\":{\"operation\":\"epoch\",\"operand\":\"hour_of_day\"},\"defaultResult\":false,\"value\":11},{\"type\":\"greater_than\",\"path\":\"/unixTime\",\"preoperation\":{\"operation\":\"epoch\",\"operand\":\"week_of_month\"},\"defaultResult\":false,\"value\":30}]}]}", ruleRep);
     }
     
 }

--- a/src/test/java/io/appform/jsonrules/ExpressionTest.java
+++ b/src/test/java/io/appform/jsonrules/ExpressionTest.java
@@ -114,8 +114,14 @@ public class ExpressionTest {
                 .build()
                 .evaluate(context));
         Assert.assertTrue(NotEqualsExpression.builder()
-                .path("/efgh")
+                .path("/NON_EXISITING_KEY")
                 .value(20)
+                .build()
+                .evaluate(context));
+        Assert.assertFalse(NotEqualsExpression.builder()
+                .path("/NON_EXISITING_KEY")
+                .value(20)
+                .defaultResult(false)
                 .build()
                 .evaluate(context));
         Assert.assertFalse(NotEqualsExpression.builder()
@@ -200,7 +206,19 @@ public class ExpressionTest {
                 .evaluate(context));
 
         Assert.assertTrue(NotInExpression.builder()
-                .path("/xyz")
+                .path("/NON_EXISITING_KEY")
+                .values(new ArrayList<String>() {
+                    {
+                        add("stupid");
+                        add("dumb");
+                    }
+                })
+                .build()
+                .evaluate(context));
+
+        Assert.assertFalse(NotInExpression.builder()
+                .path("/NON_EXISITING_KEY")
+                .defaultResult(false)
                 .values(new ArrayList<String>() {
                     {
                         add("stupid");

--- a/src/test/java/io/appform/jsonrules/ModuloOperationTest.java
+++ b/src/test/java/io/appform/jsonrules/ModuloOperationTest.java
@@ -341,7 +341,7 @@ public class ModuloOperationTest {
         final String ruleRep = rule.representation(mapper);
 
         System.out.println(ruleRep);
-        Assert.assertEquals("{\"type\":\"not\",\"children\":[{\"type\":\"or\",\"children\":[{\"type\":\"less_than\",\"path\":\"/value\",\"preoperation\":{\"operation\":\"modulo\",\"operand\":5},\"value\":11},{\"type\":\"greater_than\",\"path\":\"/value\",\"preoperation\":{\"operation\":\"modulo\",\"operand\":-5},\"value\":30}]}]}", ruleRep);
+        Assert.assertEquals("{\"type\":\"not\",\"children\":[{\"type\":\"or\",\"children\":[{\"type\":\"less_than\",\"path\":\"/value\",\"preoperation\":{\"operation\":\"modulo\",\"operand\":5},\"defaultResult\":false,\"value\":11},{\"type\":\"greater_than\",\"path\":\"/value\",\"preoperation\":{\"operation\":\"modulo\",\"operand\":-5},\"defaultResult\":false,\"value\":30}]}]}", ruleRep);
     }
     
 

--- a/src/test/java/io/appform/jsonrules/MultiplyOperationTest.java
+++ b/src/test/java/io/appform/jsonrules/MultiplyOperationTest.java
@@ -316,7 +316,7 @@ public class MultiplyOperationTest {
         final String ruleRep = rule.representation(mapper);
 
         System.out.println(ruleRep);
-        Assert.assertEquals("{\"type\":\"not\",\"children\":[{\"type\":\"or\",\"children\":[{\"type\":\"less_than\",\"path\":\"/value\",\"preoperation\":{\"operation\":\"multiply\",\"operand\":5},\"value\":11},{\"type\":\"greater_than\",\"path\":\"/value\",\"preoperation\":{\"operation\":\"multiply\",\"operand\":-5},\"value\":30}]}]}", ruleRep);
+        Assert.assertEquals("{\"type\":\"not\",\"children\":[{\"type\":\"or\",\"children\":[{\"type\":\"less_than\",\"path\":\"/value\",\"preoperation\":{\"operation\":\"multiply\",\"operand\":5},\"defaultResult\":false,\"value\":11},{\"type\":\"greater_than\",\"path\":\"/value\",\"preoperation\":{\"operation\":\"multiply\",\"operand\":-5},\"defaultResult\":false,\"value\":30}]}]}", ruleRep);
     }
     
 }

--- a/src/test/java/io/appform/jsonrules/RuleTest.java
+++ b/src/test/java/io/appform/jsonrules/RuleTest.java
@@ -38,7 +38,11 @@ public class RuleTest {
         final String ruleRepr = TestUtils.read("/simple_rule_with_default.rule");
         Rule rule = Rule.create(ruleRepr, mapper);
         JsonNode nodeWithMissingOperandPath = mapper.readTree("{ \"value\": 20, \"name\" : \"Hello\" }");
-        Assert.assertTrue(rule.matches(node));
+        Assert.assertTrue(rule.matches(nodeWithMissingOperandPath));
+
+        final String ruleRepr2 = TestUtils.read("/simple.rule");
+        Rule rule2 = Rule.create(ruleRepr2, mapper);
+        Assert.assertFalse(rule2.matches(nodeWithMissingOperandPath));
     }
 
     @Test
@@ -77,6 +81,6 @@ public class RuleTest {
         final String ruleRep = rule.representation(mapper);
 
         System.out.println(ruleRep);
-        Assert.assertEquals("{\"type\":\"not\",\"children\":[{\"type\":\"or\",\"children\":[{\"type\":\"less_than\",\"path\":\"/value\",\"value\":11},{\"type\":\"greater_than\",\"path\":\"/value\",\"value\":30}]}]}", ruleRep);
+        Assert.assertEquals("{\"type\":\"not\",\"children\":[{\"type\":\"or\",\"children\":[{\"type\":\"less_than\",\"path\":\"/value\",\"defaultResult\":false,\"value\":11},{\"type\":\"greater_than\",\"path\":\"/value\",\"defaultResult\":false,\"value\":30}]}]}", ruleRep);
     }
 }

--- a/src/test/java/io/appform/jsonrules/RuleTest.java
+++ b/src/test/java/io/appform/jsonrules/RuleTest.java
@@ -34,6 +34,14 @@ public class RuleTest {
     }
 
     @Test
+    public void testDefaultResultRule() throws Exception {
+        final String ruleRepr = TestUtils.read("/simple_rule_with_default.rule");
+        Rule rule = Rule.create(ruleRepr, mapper);
+        JsonNode nodeWithMissingOperandPath = mapper.readTree("{ \"value\": 20, \"name\" : \"Hello\" }");
+        Assert.assertTrue(rule.matches(node));
+    }
+
+    @Test
     @Ignore
     public void testPerf() throws Exception {
         final String ruleRepr = TestUtils.read("/complex.rule");

--- a/src/test/java/io/appform/jsonrules/SubtractOperationTest.java
+++ b/src/test/java/io/appform/jsonrules/SubtractOperationTest.java
@@ -283,7 +283,7 @@ public class SubtractOperationTest {
         final String ruleRep = rule.representation(mapper);
 
         System.out.println(ruleRep);
-        Assert.assertEquals("{\"type\":\"not\",\"children\":[{\"type\":\"or\",\"children\":[{\"type\":\"less_than\",\"path\":\"/value\",\"preoperation\":{\"operation\":\"subtract\",\"operand\":5},\"value\":11},{\"type\":\"greater_than\",\"path\":\"/value\",\"preoperation\":{\"operation\":\"subtract\",\"operand\":-5},\"value\":30}]}]}", ruleRep);
+        Assert.assertEquals("{\"type\":\"not\",\"children\":[{\"type\":\"or\",\"children\":[{\"type\":\"less_than\",\"path\":\"/value\",\"preoperation\":{\"operation\":\"subtract\",\"operand\":5},\"defaultResult\":false,\"value\":11},{\"type\":\"greater_than\",\"path\":\"/value\",\"preoperation\":{\"operation\":\"subtract\",\"operand\":-5},\"defaultResult\":false,\"value\":30}]}]}", ruleRep);
     }
     
 

--- a/src/test/resources/simple_rule_with_default.rule
+++ b/src/test/resources/simple_rule_with_default.rule
@@ -1,0 +1,6 @@
+{
+  "type" : "equals",
+  "path" : "/string",
+  "value" : "Hello",
+  "defaultResult": true
+}


### PR DESCRIPTION
 * Each expression now supports a `defaultResult` field which is returned in case operand path does not exist in the payload.

```json
{
  "type" : "equals",
  "path" : "/string",
  "value" : "Hello",
  "defaultResult": true
}

```

 * Addition of readme.md bit of documentation