### PR TITLE
Change JsonPath default configuration to custom configuration

### DIFF
--- a/src/main/java/io/appform/jsonrules/expressions/JsonPathBasedExpression.java
+++ b/src/main/java/io/appform/jsonrules/expressions/JsonPathBasedExpression.java
@@ -52,8 +52,14 @@ public abstract class JsonPathBasedExpression extends Expression {
     private PreOperation<?> preoperation;
     private boolean defaultResult;
 
+    private static final Configuration configuration;
+
     static {
-        Configuration.setDefaults(new JacksonConfiguration());
+        configuration = Configuration.builder()
+                .jsonProvider(new JacksonJsonProvider())
+                .mappingProvider(new JacksonMappingProvider())
+                .options(EnumSet.noneOf(Option.class))
+                .build();
     }
 
     protected JsonPathBasedExpression(ExpressionType type) {
@@ -72,7 +78,9 @@ public abstract class JsonPathBasedExpression extends Expression {
     public final boolean evaluate(ExpressionEvaluationContext context) {
         JsonNode nodeAtPath = null;
         try {
-            val nodeValue = JsonPath.read(context.getNode().toString(), path);
+            val nodeValue = JsonPath.using(configuration)
+                    .parse(context.getNode().toString())
+                    .read(path);
             if (nodeValue != null) {
                 nodeAtPath = mapper.valueToTree(nodeValue);
             } else {


### PR DESCRIPTION
Changed how the JsonPath configuration is provided to the JsonPath class.

JsonPath uses a static default configuration which can be set by any class at any time. json-rules set the default configuration when the class is initialized, but it may get overridden by other classes at runtime.

In the Configuration, one can pass a list of options which affect how the response of JsonPath will look like. This was causing a problem in one of our use case, where we don't want to pass any option.
