### PR TITLE
Use JacksonJsonNodeJsonProvider for faster reads

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.appform.rules</groupId>
     <artifactId>json-rules</artifactId>
-    <version>1.0.14</version>
+    <version>1.0.15</version>
     <name>JSON Rules</name>
     <description>Json serializable rule engine</description>
     <url>https://github.com/santanusinha/json-rules</url>

--- a/src/main/java/io/appform/jsonrules/expressions/array/CollectionJsonPathBasedExpression.java
+++ b/src/main/java/io/appform/jsonrules/expressions/array/CollectionJsonPathBasedExpression.java
@@ -17,22 +17,24 @@
 
 package io.appform.jsonrules.expressions.array;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.jayway.jsonpath.JsonPath;
 import io.appform.jsonrules.ExpressionEvaluationContext;
 import io.appform.jsonrules.ExpressionType;
 import io.appform.jsonrules.expressions.JsonPathBasedExpression;
 import io.appform.jsonrules.expressions.preoperation.PreOperation;
-import io.appform.jsonrules.utils.ComparisonUtils;
+import io.appform.jsonrules.utils.JsonUtils;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.Singular;
 import lombok.ToString;
 
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
-import static io.appform.jsonrules.utils.ComparisonUtils.mapper;
+import static io.appform.jsonrules.utils.JsonUtils.mapper;
 
 /**
  * All collection operable expressions
@@ -60,13 +62,13 @@ public abstract class CollectionJsonPathBasedExpression extends JsonPathBasedExp
     @Override
     protected final boolean evaluate(ExpressionEvaluationContext context, String path, JsonNode evaluatedNode) {
         if (extractValues) {
-            JsonNode jsonNode = mapper.valueToTree(JsonPath.using(ComparisonUtils.SUPPRESS_EXCEPTION_CONFIG)
-                    .parse(context.getNode().toString()).read(String.valueOf(valuesPath)));
+            JsonNode jsonNode = JsonPath.using(JsonUtils.SUPPRESS_EXCEPTION_CONFIG)
+                    .parse(context.getNode()).read(String.valueOf(valuesPath));
             if (jsonNode == null || !jsonNode.isArray()) {
                 return false;
             }
             // fetch values from @values path as a set.
-            final HashSet<Object> extractedPathValues = new HashSet<>(JsonPath.read(jsonNode.toString(), "$"));
+            final Set<Object> extractedPathValues = new HashSet<>(mapper.convertValue(jsonNode, new TypeReference<Collection<Object>>() {}));
             return evaluate(evaluatedNode, extractedPathValues);
         }
 

--- a/src/main/java/io/appform/jsonrules/expressions/array/ContainsAllExpression.java
+++ b/src/main/java/io/appform/jsonrules/expressions/array/ContainsAllExpression.java
@@ -17,14 +17,16 @@
 
 package io.appform.jsonrules.expressions.array;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.Sets;
-import com.jayway.jsonpath.JsonPath;
 import io.appform.jsonrules.ExpressionType;
 import io.appform.jsonrules.ExpressionVisitor;
 import io.appform.jsonrules.expressions.preoperation.PreOperation;
+import io.appform.jsonrules.utils.JsonUtils;
 import lombok.*;
 
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -52,7 +54,8 @@ public class ContainsAllExpression extends CollectionJsonPathBasedExpression {
         if (!evaluatedNode.isArray()) {
             return false;
         }
-        final Set<Object> pathValues = new HashSet<>(JsonPath.read(evaluatedNode.toString(), "$"));
+        final Set<Object> pathValues = new HashSet<>(JsonUtils.mapper.convertValue(evaluatedNode, new TypeReference<Collection<Object>>() {
+        }));
         final int commonElementsSize = Sets.intersection(values, pathValues).size();
         return commonElementsSize == pathValues.size();
     }

--- a/src/main/java/io/appform/jsonrules/expressions/array/ContainsAnyExpression.java
+++ b/src/main/java/io/appform/jsonrules/expressions/array/ContainsAnyExpression.java
@@ -17,14 +17,16 @@
 
 package io.appform.jsonrules.expressions.array;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.Sets;
-import com.jayway.jsonpath.JsonPath;
 import io.appform.jsonrules.ExpressionType;
 import io.appform.jsonrules.ExpressionVisitor;
 import io.appform.jsonrules.expressions.preoperation.PreOperation;
+import io.appform.jsonrules.utils.JsonUtils;
 import lombok.*;
 
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -52,7 +54,8 @@ public class ContainsAnyExpression extends CollectionJsonPathBasedExpression {
         if (null == values || values.isEmpty() || !evaluatedNode.isArray()) {
             return false;
         }
-        final Set<Object> pathValues = new HashSet<>(JsonPath.read(evaluatedNode.toString(), "$"));
+        final Set<Object> pathValues = new HashSet<>(JsonUtils.mapper.convertValue(evaluatedNode,
+                new TypeReference<Collection<Object>>() {}));
         return !Sets.intersection(values, pathValues).isEmpty();
 
     }

--- a/src/main/java/io/appform/jsonrules/expressions/numeric/NumericJsonPathBasedExpression.java
+++ b/src/main/java/io/appform/jsonrules/expressions/numeric/NumericJsonPathBasedExpression.java
@@ -23,12 +23,10 @@ import io.appform.jsonrules.ExpressionEvaluationContext;
 import io.appform.jsonrules.ExpressionType;
 import io.appform.jsonrules.expressions.JsonPathBasedExpression;
 import io.appform.jsonrules.expressions.preoperation.PreOperation;
-import io.appform.jsonrules.utils.ComparisonUtils;
+import io.appform.jsonrules.utils.JsonUtils;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
-
-import static io.appform.jsonrules.utils.ComparisonUtils.mapper;
 
 /**
  * All numeric binary expressions
@@ -59,8 +57,8 @@ public abstract class NumericJsonPathBasedExpression extends JsonPathBasedExpres
 
         Number numericalValue;
         if (extractValueFromPath) {
-            JsonNode jsonNode = mapper.valueToTree(JsonPath.using(ComparisonUtils.SUPPRESS_EXCEPTION_CONFIG)
-                    .parse(context.getNode().toString()).read(String.valueOf(value)));
+            JsonNode jsonNode = JsonPath.using(JsonUtils.SUPPRESS_EXCEPTION_CONFIG)
+                    .parse(context.getNode()).read(String.valueOf(value));
             if (jsonNode == null) {
                 return false;
             }

--- a/src/main/java/io/appform/jsonrules/expressions/string/StringJsonPathBasedExpression.java
+++ b/src/main/java/io/appform/jsonrules/expressions/string/StringJsonPathBasedExpression.java
@@ -23,12 +23,10 @@ import io.appform.jsonrules.ExpressionEvaluationContext;
 import io.appform.jsonrules.ExpressionType;
 import io.appform.jsonrules.expressions.JsonPathBasedExpression;
 import io.appform.jsonrules.expressions.preoperation.PreOperation;
-import io.appform.jsonrules.utils.ComparisonUtils;
+import io.appform.jsonrules.utils.JsonUtils;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
-
-import static io.appform.jsonrules.utils.ComparisonUtils.mapper;
 
 /**
  * All string operable expressions
@@ -59,8 +57,8 @@ public abstract class StringJsonPathBasedExpression extends JsonPathBasedExpress
             return false;
         }
         if (extractValueFromPath) {
-            JsonNode jsonNode = mapper.valueToTree(JsonPath.using(ComparisonUtils.SUPPRESS_EXCEPTION_CONFIG)
-                    .parse(context.getNode().toString()).read(value));
+            JsonNode jsonNode = JsonPath.using(JsonUtils.SUPPRESS_EXCEPTION_CONFIG)
+                    .parse(context.getNode()).read(value);
             if (jsonNode == null || !jsonNode.isTextual()) {
                 return false;
             }

--- a/src/main/java/io/appform/jsonrules/utils/ComparisonUtils.java
+++ b/src/main/java/io/appform/jsonrules/utils/ComparisonUtils.java
@@ -18,19 +18,13 @@
 package io.appform.jsonrules.utils;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.jayway.jsonpath.Configuration;
 import com.jayway.jsonpath.JsonPath;
-import com.jayway.jsonpath.Option;
 import io.appform.jsonrules.ExpressionEvaluationContext;
 
 /**
  * Created by santanu on 15/9/16.
  */
 public class ComparisonUtils {
-    public static final Configuration SUPPRESS_EXCEPTION_CONFIG = Configuration.defaultConfiguration()
-            .addOptions(Option.SUPPRESS_EXCEPTIONS);
-    public static final ObjectMapper mapper = new ObjectMapper();
 
     public static int compare(JsonNode evaluatedNode, Object value) {
         int comparisonResult = 0;
@@ -78,8 +72,7 @@ public class ComparisonUtils {
     public static boolean compareForEquality(ExpressionEvaluationContext context, JsonNode evaluatedNode,
             Object value) {
         final boolean nodeMissingOrNullCheck = isNodeMissingOrNull(evaluatedNode);
-        final JsonNode jsonNode = mapper.valueToTree(JsonPath.using(SUPPRESS_EXCEPTION_CONFIG)
-                .parse(context.getNode().toString()).read(String.valueOf(value)));
+        final JsonNode jsonNode = JsonPath.using(JsonUtils.SUPPRESS_EXCEPTION_CONFIG).parse(context.getNode()).read(String.valueOf(value));
 
         if (isNodeMissingOrNull(jsonNode)) {
             return nodeMissingOrNullCheck;
@@ -102,8 +95,8 @@ public class ComparisonUtils {
     public static boolean compareForNotEquals(ExpressionEvaluationContext context, JsonNode evaluatedNode,
             Object value) {
         final boolean nodeMissingOrNullCheck = isNodeMissingOrNull(evaluatedNode);
-        final JsonNode jsonNode = mapper.valueToTree(JsonPath.using(SUPPRESS_EXCEPTION_CONFIG)
-                .parse(context.getNode().toString()).read(String.valueOf(value)));
+        final JsonNode jsonNode = JsonPath.using(JsonUtils.SUPPRESS_EXCEPTION_CONFIG)
+                .parse(context.getNode()).read(String.valueOf(value));
 
         if (isNodeMissingOrNull(jsonNode)) {
             return !nodeMissingOrNullCheck;

--- a/src/main/java/io/appform/jsonrules/utils/JsonUtils.java
+++ b/src/main/java/io/appform/jsonrules/utils/JsonUtils.java
@@ -1,0 +1,16 @@
+package io.appform.jsonrules.utils;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.Option;
+import com.jayway.jsonpath.spi.json.JacksonJsonNodeJsonProvider;
+import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
+
+public class JsonUtils {
+    public static final Configuration SUPPRESS_EXCEPTION_CONFIG = Configuration.builder()
+            .jsonProvider(new JacksonJsonNodeJsonProvider())
+            .mappingProvider(new JacksonMappingProvider())
+            .options(Option.SUPPRESS_EXCEPTIONS)
+            .build();
+    public static final ObjectMapper mapper = new ObjectMapper();
+}


### PR DESCRIPTION
This Merge Request optimizes the performance by eliminating unnecessary serialization and deserialization of JsonNode. Instead, it leverages JacksonJsonNodeJsonProvider that operates directly on JsonNode, resulting in a more efficient process.