### PR TITLE
[PERF] Optimise JacksonJsonNodeJsonProvider implementation

### DIFF
--- a/json-rules-benchmarks/pom.xml
+++ b/json-rules-benchmarks/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.appform.rules</groupId>
         <artifactId>json-rules</artifactId>
-        <version>1.0.16</version>
+        <version>1.0.17</version>
     </parent>
 
     <artifactId>json-rules-benchmarks</artifactId>

--- a/json-rules-benchmarks/src/main/java/io/appform/jsonrules/benchmarks/ExpressionEvaluationBenchmark.java
+++ b/json-rules-benchmarks/src/main/java/io/appform/jsonrules/benchmarks/ExpressionEvaluationBenchmark.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.appform.jsonrules.Expression;
 import io.appform.jsonrules.ExpressionEvaluationContext;
 import io.appform.jsonrules.config.JsonRulesConfiguration;
+import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.infra.Blackhole;
 
 import java.util.HashMap;

--- a/json-rules-core/pom.xml
+++ b/json-rules-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.appform.rules</groupId>
         <artifactId>json-rules</artifactId>
-        <version>1.0.16</version>
+        <version>1.0.17</version>
     </parent>
 
     <artifactId>json-rules-core</artifactId>

--- a/json-rules-core/pom.xml
+++ b/json-rules-core/pom.xml
@@ -11,4 +11,13 @@
     <artifactId>json-rules-core</artifactId>
     <packaging>jar</packaging>
 
+    <dependencies>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>4.11.0</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
 </project>

--- a/json-rules-core/src/main/java/io/appform/jsonrules/config/JacksonConfiguration.java
+++ b/json-rules-core/src/main/java/io/appform/jsonrules/config/JacksonConfiguration.java
@@ -7,6 +7,7 @@ import com.jayway.jsonpath.spi.json.JacksonJsonNodeJsonProvider;
 import com.jayway.jsonpath.spi.json.JsonProvider;
 import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
 import com.jayway.jsonpath.spi.mapper.MappingProvider;
+import io.appform.jsonrules.jsonpath.providers.OptimizedJacksonJsonNodeJsonProvider;
 import lombok.Getter;
 
 import java.util.EnumSet;
@@ -16,7 +17,7 @@ public final class JacksonConfiguration implements Configuration.Defaults {
     @Getter
     private static final JacksonConfiguration instance = new JacksonConfiguration();
 
-    private final JacksonJsonNodeJsonProvider jsonProvider = new JacksonJsonNodeJsonProvider();
+    private final JacksonJsonNodeJsonProvider jsonProvider = new OptimizedJacksonJsonNodeJsonProvider(options());
     private final JacksonMappingProvider mappingProvider = new JacksonMappingProvider();
 
     @Override

--- a/json-rules-core/src/main/java/io/appform/jsonrules/jsonpath/providers/OptimizedJacksonJsonNodeJsonProvider.java
+++ b/json-rules-core/src/main/java/io/appform/jsonrules/jsonpath/providers/OptimizedJacksonJsonNodeJsonProvider.java
@@ -2,34 +2,19 @@ package io.appform.jsonrules.jsonpath.providers;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.google.common.annotations.VisibleForTesting;
 import com.jayway.jsonpath.Option;
 import com.jayway.jsonpath.spi.json.JacksonJsonNodeJsonProvider;
+import lombok.Getter;
 
 import java.util.Set;
 
 public class OptimizedJacksonJsonNodeJsonProvider extends JacksonJsonNodeJsonProvider {
+    @Getter
     private boolean shouldReturnPathAsList;
 
     public OptimizedJacksonJsonNodeJsonProvider(Set<Option> options) {
         this.shouldReturnPathAsList = options.contains(Option.AS_PATH_LIST);
-    }
-
-    private ArrayNode toJsonArray(Object o) {
-        return (ArrayNode) o;
-    }
-
-    private JsonNode createJsonElement(Object o) {
-        if (o != null) {
-            // jlolling: avoid creating a cloned node: bug #211
-            if (o instanceof JsonNode) {
-                return (JsonNode) o;
-            } else {
-                // [PATCHED]
-                return shouldReturnPathAsList ? objectMapper.valueToTree(o) : null;
-            }
-        } else {
-            return null;
-        }
     }
 
     @Override
@@ -46,4 +31,23 @@ public class OptimizedJacksonJsonNodeJsonProvider extends JacksonJsonNodeJsonPro
         }
     }
 
+    @VisibleForTesting
+    JsonNode createJsonElement(Object o) {
+        if (o != null) {
+            // jlolling: avoid creating a cloned node: bug #211
+            if (o instanceof JsonNode) {
+                return (JsonNode) o;
+            } else {
+                // [PATCHED]
+                // Convert the object to a JsonNode only if Option.AS_PATH_LIST is set
+                return shouldReturnPathAsList ? objectMapper.valueToTree(o) : null;
+            }
+        } else {
+            return null;
+        }
+    }
+
+    private ArrayNode toJsonArray(Object o) {
+        return (ArrayNode) o;
+    }
 }

--- a/json-rules-core/src/main/java/io/appform/jsonrules/jsonpath/providers/OptimizedJacksonJsonNodeJsonProvider.java
+++ b/json-rules-core/src/main/java/io/appform/jsonrules/jsonpath/providers/OptimizedJacksonJsonNodeJsonProvider.java
@@ -1,0 +1,49 @@
+package io.appform.jsonrules.jsonpath.providers;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.jayway.jsonpath.Option;
+import com.jayway.jsonpath.spi.json.JacksonJsonNodeJsonProvider;
+
+import java.util.Set;
+
+public class OptimizedJacksonJsonNodeJsonProvider extends JacksonJsonNodeJsonProvider {
+    private boolean shouldReturnPathAsList;
+
+    public OptimizedJacksonJsonNodeJsonProvider(Set<Option> options) {
+        this.shouldReturnPathAsList = options.contains(Option.AS_PATH_LIST);
+    }
+
+    private ArrayNode toJsonArray(Object o) {
+        return (ArrayNode) o;
+    }
+
+    private JsonNode createJsonElement(Object o) {
+        if (o != null) {
+            // jlolling: avoid creating a cloned node: bug #211
+            if (o instanceof JsonNode) {
+                return (JsonNode) o;
+            } else {
+                // [PATCHED]
+                return shouldReturnPathAsList ? objectMapper.valueToTree(o) : null;
+            }
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public void setArrayIndex(Object array, int index, Object newValue) {
+        if (!isArray(array)) {
+            throw new UnsupportedOperationException();
+        } else {
+            ArrayNode arrayNode = toJsonArray(array);
+            if (index == arrayNode.size()){
+                arrayNode.add(createJsonElement(newValue));
+            }else {
+                arrayNode.set(index, createJsonElement(newValue));
+            }
+        }
+    }
+
+}

--- a/json-rules-core/src/test/java/io/appform/jsonrules/jsonpath/providers/OptimizedJacksonJsonNodeJsonProviderTest.java
+++ b/json-rules-core/src/test/java/io/appform/jsonrules/jsonpath/providers/OptimizedJacksonJsonNodeJsonProviderTest.java
@@ -1,0 +1,99 @@
+package io.appform.jsonrules.jsonpath.providers;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.google.common.collect.ImmutableSet;
+import com.jayway.jsonpath.Option;
+import lombok.val;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+public class OptimizedJacksonJsonNodeJsonProviderTest {
+
+    private OptimizedJacksonJsonNodeJsonProvider provider;
+    private ObjectMapper objectMapper;
+
+    public OptimizedJacksonJsonNodeJsonProviderTest() {
+        objectMapper = mock(ObjectMapper.class);
+        provider = new OptimizedJacksonJsonNodeJsonProvider(ImmutableSet.of(Option.AS_PATH_LIST));
+    }
+
+    @Test
+    public void testConstructorWithOptionAsPathList() {
+        provider = new OptimizedJacksonJsonNodeJsonProvider(ImmutableSet.of(Option.AS_PATH_LIST));
+        assertTrue(provider.isShouldReturnPathAsList());
+    }
+
+    @Test
+    public void testConstructorWithoutOptionAsPathList() {
+        provider = new OptimizedJacksonJsonNodeJsonProvider(Collections.emptySet());
+        assertFalse(provider.isShouldReturnPathAsList());
+    }
+
+    @Test
+    public void testSetArrayIndexWithNonArrayThrowsException() {
+        try {
+            provider.setArrayIndex("notAnArray", 0, "value");
+            fail("Expected UnsupportedOperationException to be thrown");
+        } catch (UnsupportedOperationException e) {
+            // Test passes
+        }
+    }
+
+    @Test
+    public void testSetArrayIndexWithValidArrayAndIndex() {
+        ArrayNode arrayNode = mock(ArrayNode.class);
+        when(arrayNode.size()).thenReturn(1);
+
+        provider.setArrayIndex(arrayNode, 0, "value");
+
+        verify(arrayNode).set(eq(0), any(JsonNode.class));
+    }
+
+    @Test
+    public void testSetArrayIndexWithValidArrayAndIndexEqualToSize() {
+        ArrayNode arrayNode = mock(ArrayNode.class);
+        when(arrayNode.size()).thenReturn(1);
+
+        provider.setArrayIndex(arrayNode, 1, "value");
+
+        verify(arrayNode).add(any(JsonNode.class));
+    }
+
+    @Test
+    public void testCreateJsonElementWithNullValue() {
+        JsonNode result = provider.createJsonElement(null);
+        assertNull(result);
+    }
+
+    @Test
+    public void testCreateJsonElementWithJsonNode() {
+        JsonNode jsonNode = mock(JsonNode.class);
+        JsonNode result = provider.createJsonElement(jsonNode);
+        assertSame(jsonNode, result);
+    }
+
+    @Test
+    public void testCreateJsonElementWithNonJsonNode() {
+        provider = new OptimizedJacksonJsonNodeJsonProvider(ImmutableSet.of());
+        Object value = "testValue";
+
+        JsonNode result = provider.createJsonElement(value);
+        assertNull(result);
+        verifyNoInteractions(objectMapper);
+
+        provider = new OptimizedJacksonJsonNodeJsonProvider(ImmutableSet.of(Option.AS_PATH_LIST));
+        val mockNode = mock(JsonNode.class);
+        when(objectMapper.valueToTree(value)).thenReturn(mockNode);
+        when(mockNode.toString()).thenReturn("\"testValue\"");
+
+        JsonNode result1 = provider.createJsonElement(value);
+        assertNotNull(result1);
+        assertEquals(mockNode.toString(), result1.toString());
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.appform.rules</groupId>
     <artifactId>json-rules</artifactId>
-    <version>1.0.16</version>
+    <version>1.0.17</version>
     <name>JSON Rules</name>
     <packaging>pom</packaging>
     <description>Json serializable rule engine</description>

--- a/run_benchmark.sh
+++ b/run_benchmark.sh
@@ -5,7 +5,7 @@ set -x
 MODULE_TARGET_DIR=json-rules-benchmarks/target
 
 if [ $1 == "-prof" ]; then
-  java -jar $MODULE_TARGET_DIR/benchmarks.jar -prof "async:libPath=$HOME/async-profiler/lib/libasyncProfiler.dylib;interval=100000;event=itimer;output=flamegraph;dir=benchmark-results"
+  java -jar $MODULE_TARGET_DIR/benchmarks.jar -wi 10 -i 5 -f 1 -prof "async:libPath=$HOME/async-profiler/lib/libasyncProfiler.dylib;interval=100000;event=itimer;output=flamegraph;dir=benchmark-results"
 else
   java -jar json-rules-benchmarks/target/benchmarks.jar -wi 10 -i 5 -f 1 -gc true
 fi

--- a/run_benchmark.sh
+++ b/run_benchmark.sh
@@ -7,5 +7,5 @@ MODULE_TARGET_DIR=json-rules-benchmarks/target
 if [ $1 == "-prof" ]; then
   java -jar $MODULE_TARGET_DIR/benchmarks.jar -wi 10 -i 5 -f 1 -prof "async:libPath=$HOME/async-profiler/lib/libasyncProfiler.dylib;interval=100000;event=itimer;output=flamegraph;dir=benchmark-results"
 else
-  java -jar json-rules-benchmarks/target/benchmarks.jar -wi 10 -i 5 -f 1 -gc true
+  java -jar $MODULE_TARGET_DIR/benchmarks.jar -wi 10 -i 5 -f 1 -gc true
 fi


### PR DESCRIPTION
Problem:
JsonPath internally does lookups of query paths by converting them to array index operations.
For example, if queried path is `$.a.b.c`, it converts the same to `$['a']['b']['c']` and performs lookup for the same by using the supplied json provider. If JacksonJsonNodeJsonProvider is the configured json provider, then this results in a conversion of the expression from String to TextNode to make sure an object of type JsonNode is always returned. This conversion is achieved by calling mapper.valueToTree(obj) function. However, this computation is only necessary when Option.AS_PATH_LIST is set to true. When this option is set, JsonPath is expected to return the path of the evaluation hits along with the value of evaluation result. 

Solution:
Since the default value is false and json-rules doesn't really need this feature, I have patched JacksonJsonNodeJsonProvider to do this only selectively when this option is set. This new provider is used by default.

Result:
This is resulting in a 13% throughput improvement over the current implementation but the performance gain can be bigger/lower in production since it depends on the number of path queries in the predicate rule. This change is also expected to show a good amount of CPU usage reduction. 